### PR TITLE
Footer date count displaying

### DIFF
--- a/src/scripts/Data/DataAccess.js
+++ b/src/scripts/Data/DataAccess.js
@@ -12,7 +12,8 @@ const applicationState = {
         displayMessages: [],
         newPost: false,
         datePosted: null,
-        newMessage: false
+        newMessage: false,
+        filteredPostsArray: []
     }
 }
 
@@ -239,4 +240,10 @@ export const deletePost = (id) => {
                 mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
             }
         )
+}
+
+
+export const setDatePosted = (post) => {
+    applicationState.feed.datePosted = post
+    mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
 }

--- a/src/scripts/Footer.js
+++ b/src/scripts/Footer.js
@@ -1,6 +1,63 @@
 //include a dropdown for date to filter the posts from a selected year
 
-import { getUsers } from "./Data/DataAccess.js"
+import { getPosts, getUsers } from "./Data/DataAccess.js"
+
+
+/*
+    Calculate the number of posts since a given year
+*/
+const postsSince = (year) => {
+    const posts = getPosts()
+    const epoch = year
+    const postsSinceYear = []
+
+    for (const post of posts) {
+        const yearTimestamp = post.timestamp.slice(post.timestamp.length - 4, post.timestamp.length)
+        if (parseInt(yearTimestamp) >= epoch) {
+            postsSinceYear.push(post)
+        }
+    }
+
+    return postsSinceYear.length
+}
+
+/*
+    Initial state of post count
+*/
+let yearChosenByUser = 2022
+let postSinceYearChosen = postsSince(yearChosenByUser)
+
+
+//create event listeners for each dropdown section
+//event listener for year selection:
+const mainContainer = document.querySelector("#container")
+mainContainer.addEventListener("change", (event) => {
+
+    if (event.target.id === "yearSelection") {
+        const yearAsNumber = parseInt(event.target.value)
+
+        // Update the two component state variables
+        yearChosenByUser = yearAsNumber
+        postSinceYearChosen = postsSince(yearAsNumber)
+
+
+        // Broadcast your own, custom event stating that some state changed
+        mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
+
+        //function that has variable as a year and parInt - ('01/01/' + ___)
+
+        //conditional that checks if post date year is equal to year selection value
+
+
+        //store matching year in empty array
+        //return the array as posts filtered through
+
+
+    
+    }
+})
+
+
 
 //include a dropdown for users to filters posts from selected user
 
@@ -8,8 +65,9 @@ import { getUsers } from "./Data/DataAccess.js"
 
 export const Footer = () => {
     let user = getUsers()
-    let yearChosenByUser = 2020
-    let postSinceYearChosen = 0
+    const posts = getPosts()
+    
+
 
     // HTML to be returned to GiffyGram component
     let html = ""
@@ -18,12 +76,12 @@ export const Footer = () => {
         <footer class="footer">
             <div class="footer__item">
                 Posts since <select id="yearSelection">
+                    <option ${yearChosenByUser === 2022 ? "selected" : ""}>2022</option>
+                    <option ${yearChosenByUser === 2021 ? "selected" : ""}>2021</option>
                     <option ${yearChosenByUser === 2020 ? "selected" : ""}>2020</option>
                     <option ${yearChosenByUser === 2019 ? "selected" : ""}>2019</option>
-                    <option ${yearChosenByUser === 2018 ? "selected" : ""}>2018</option>
-                    <option ${yearChosenByUser === 2017 ? "selected" : ""}>2017</option>
                 </select>
-                <span id="postCount">${postSinceYearChosen}</span>
+                <span id="postCount">${postsSince(yearChosenByUser)}</span>
             </div>
             
             <div class="footer__item">

--- a/src/scripts/Footer.js
+++ b/src/scripts/Footer.js
@@ -12,7 +12,7 @@ const postsSince = (year) => {
     const postsSinceYear = []
 
     for (const post of posts) {
-        const yearTimestamp = post.timestamp.slice(post.timestamp.length - 4, post.timestamp.length)
+        const yearTimestamp = post.timestamp.toString().slice(post.timestamp.length - 4, post.timestamp.length)
         if (parseInt(yearTimestamp) >= epoch) {
             postsSinceYear.push(post)
         }

--- a/src/styles/feed.css
+++ b/src/styles/feed.css
@@ -11,9 +11,9 @@
     bottom: 0;
     background-color: grey;
     width: 100% ;
-justify-content:start;
-gap:3em;
-padding: 15px;
+    justify-content:start;
+    gap:3em;
+    padding: 15px;
 
 }
 


### PR DESCRIPTION
# Description

Added an event listener for the date posted element of footer. Displayed posts since count should now update to the number of the amount of posts since that selected year.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] pull code and serve - go to footer and notice default value of 2022 year and 8 post count, then select a new year to see if count updates.



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
